### PR TITLE
Update via.physics.Colliders in RE2 RSZ JSON

### DIFF
--- a/resources/patches/rszre2_patch.json
+++ b/resources/patches/rszre2_patch.json
@@ -33946,20 +33946,20 @@
 			{
 				"align": 1,
 				"array": false,
-				"name": "v4",
+				"name": "Static",
 				"native": true,
 				"original_type": "",
 				"size": 1,
-				"type": "Data"
+				"type": "Bool"
 			},
 			{
 				"align": 4,
 				"array": true,
-				"name": "v5",
+				"name": "Colliders",
 				"native": true,
-				"original_type": "",
+				"original_type": "via.physics.Collider",
 				"size": 4,
-				"type": "Data"
+				"type": "Object"
 			}
 		],
 		"name": "via.physics.Colliders"


### PR DESCRIPTION
I notice that RE4R already has the correct information for this type, but a lot of the other games don't. If object fields aren't identified, our C# library to rebuild the files can't link the instances correctly.
