### PR TITLE
docs: add Related Resources section (MH Wilds Guides companion guide)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,10 @@ If you want to run REasy on Linux and encounter the error "Aborted" on launch, t
 
 If you appreciate my work and would like to support the development of the tool, you can support me through this [link](https://linktr.ee/seifhassine)
 
+## Related Resources
+
+- [MH Wilds Guides](https://mhwildsguides.xyz/) — Monster Hunter Wilds weapon tier lists, monster guides, armor builds, and skill combos.
+
 ## License, Contributions:
 
 REasy is under MIT license.


### PR DESCRIPTION
Thanks for building REasy — save tooling is a natural companion to player-facing MH Wilds guides.

This PR adds a small `## Related Resources` section pointing to a companion player-facing guide site:

- [MH Wilds Guides](https://mhwildsguides.xyz/) — Monster Hunter Wilds weapon tier lists, monster guides, armor builds, and skill combos.

The change is purely additive — no existing sections modified, no dependencies touched. Happy to trim the wording, drop the entry, or move it elsewhere if it feels off-scope.

_(Insertion strategy: `before:## License`.)_